### PR TITLE
Adding tutorials to the BT page on the tf2sr wiki

### DIFF
--- a/docs/tutorials/any-percent/02-bt-7274.mdx
+++ b/docs/tutorials/any-percent/02-bt-7274.mdx
@@ -215,6 +215,8 @@ CKs + the speed you gained from the Ravine Setup nade.
 
 ### Slant Boost
 
+<YouTube youTubeId="v3d85td4GL4" />
+
 :::
 
 ### Enemy Clear
@@ -241,6 +243,8 @@ To do the DMR Strat you need to perform *Slant Boost* for *Runup*.
 ## Titan Tutorial
 
 :::diffe
+
+<YouTube youTubeId="nQ-OvGMY270" />
 
 
 :::


### PR DESCRIPTION
I made a tutorial for the BT slant boost after grabbing battery 2, and a tutorial for the BT titan turtorial.