### PR TITLE
Adding tutorials for BT and B2

### DIFF
--- a/docs/tutorials/any-percent/02-bt-7274.mdx
+++ b/docs/tutorials/any-percent/02-bt-7274.mdx
@@ -215,7 +215,7 @@ CKs + the speed you gained from the Ravine Setup nade.
 
 ### Slant Boost
 
-<YouTube youTubeId="v3d85td4GL4" />
+<YouTube youTubeId="jxLTBBusvvI" />
 
 :::
 
@@ -223,7 +223,9 @@ CKs + the speed you gained from the Ravine Setup nade.
 
 :::diffe
 
-### Nade Lineups
+### 2 Frag Enemy Clear
+
+<YouTube youTubeId="OYz6V-DRkGk" />
 
 :::
 

--- a/docs/tutorials/any-percent/11-beacon-2.mdx
+++ b/docs/tutorials/any-percent/11-beacon-2.mdx
@@ -69,6 +69,8 @@ Try out both and see what works best for you!
 
 #### Frag Heatsink
 
+<YouTube youTubeId="3_wGU8u9OcM"/>
+
 #### Softball Heatsink (If Softball available)
 
 :::


### PR DESCRIPTION
Added tutorials for frag heatsink skip, and for the battery 2 enemy clear. Also redid the battery 2 slant boost tutorial, since that's one that definitely benefits from having a speedometer.