### PR TITLE
[Gauntlet] Add romanized mandarin at audio cue 

### DIFF
--- a/docs/tutorials/any-percent/01-gauntlet.mdx
+++ b/docs/tutorials/any-percent/01-gauntlet.mdx
@@ -24,7 +24,7 @@ With the exception of wallrun skip, this section can be thought of as an autoscr
 
 The dialogue cues to pay attention to are:
 - You should reach the first wallrun in time so that Lastimosa has **not** finished the line "...enhanced mobility becomes second nature". Any dialogue starting from the line "beautiful, isn't it?" will lose time.
-- The first wallrun doesn't become grabbable until after Lastimosa has finished that line, however. In Mandarin, jump onto the wall as Lastimosa says "...ee-yon **su hai**". // [we should find out what the actual mandarin is]
+- The first wallrun doesn't become grabbable until after Lastimosa has finished that line, however. In Mandarin, jump onto the wall as Lastimosa says ["... fănyìng yī**yàng** zìràn"](https://youtu.be/Z-jQlLVM980?feature=shared&t=67). 
 - When sliding under the rocks, reach the next area quickly enough that Lastimosa does **not** say the bad dialogue "Under here, stay low".
 - Reach from here all the way to the firing range quickly enough that Lastimosa does **not** say any dialogue past the line "...people like you".
 


### PR DESCRIPTION
It's not that clear that it's a link since it's orange rather than the traditional blue color. I do however still feel like it's good to have the actual audio linked, if people miss it then they don't miss out on anything compared to how it was before.

The emphasis in the cue has been moved to yi**yang** rather than **ziran** to better reflect the video that is linked.