### PR TITLE
[BT] Add references to blaidans 2025 tutorial 

### DIFF
--- a/docs/tutorials/any-percent/02-bt-7274.mdx
+++ b/docs/tutorials/any-percent/02-bt-7274.mdx
@@ -152,11 +152,14 @@ Important to both Circle room and double wallkick (with the former being the mor
 
 ## Prowler Pad
 
-:::diffm
-
+:::diffe
 ### Standard Route
+<YouTube youTubeId="UC3IFlIfjyI" skipTo={{ h:0, m:4, s:2 }} />
+:::
 
-After doing your preferred death river route, cloak to avoid startling the group of grunts and slidehop either to the right or over them (you may have to slide over their heads depending on where exactly they are when you arrive). If you plan on doing DMR Clear at the end of the level, swap to the r-201 and grab the DMR out of either of the weapon containers (the first one is the safer option since the second one contains arc grenades, and getting rid of your frag grenades will mess up many strats and likely make you reset your run if you fail to realize). After this, jump between the two walls on the right side and cfeb after coming around the corner to the next section. Slidehop down to the [spectre caves? what do we call this?] and shoot the prowler if it attempts to block your path. Make your way up the right side of the "ramp" around the rock in the middle of the room and either wallrun to the prowler pad and shoot the prowler as you cfeb off, or crouch kick the wall, which gives you an angle to go around the prowler but requires that you keep a decent bit of speed through the ramp. Once you reach the prowler pad, Cooper's jumpkit will fully calibrate, and you've finally obtained your double jump. Congratulations! The double jump gives you enough height to double jump to the wall on the left and skip the intended tutorial route, so do that and continue into the ship.
+:::diffm
+### Setup for DMR Clear
+ If you plan on doing DMR Clear at the end of the level, swap to the r-201 right after Death River and grab the DMR out of either of the weapon containers (the first one is the safer option since the second one contains arc grenades, and getting rid of your frag grenades will mess up many strats and likely make you reset your run if you fail to realize). After this, jump between the two walls on the right side and cfeb after coming around the corner to the next section.
 
 :::
 
@@ -172,16 +175,11 @@ On the second to last platform before the slant, sprint off of the right side (d
 
 :::
 
-:::diffh
-
-### Slant Shot
-
-:::
 
 :::diffh
 
 ### Slant Shot
-
+<YouTube youTubeId="UC3IFlIfjyI" skipTo={{ h:0, m:21, s:29 }} />
 :::
 
 ## River
@@ -209,6 +207,8 @@ If you don't want to do a frag boost here and want do an easier variation just s
 :::diffh
 
 ### Blaidan's Setup
+
+<YouTube youTubeId="UC3IFlIfjyI" skipTo={{ h:0, m:16, s:55 }} />
 
 ### Joshfrag
 
@@ -278,7 +278,7 @@ If you've managed to build and keep between 70-80km/h during ravine, you can cro
 
 ### DMR Strat
 
-After performing slant boost, a few crouch kicks off the walls will allow you to keep enough speed and height to land on top of the rock archway, from there, quickly scope in and perform 2 quick body shots to kill the spectre on top. Afterwards, quickly slide down and pull a grenade to kill the remaining three spectres, finishing off any that survive with the DMR. Missing the kill on the top spectre can lose a lot of time, but it's possible to back this up by throwing a grenade in the right spot if you have one to spare.
+<YouTube youTubeId="UC3IFlIfjyI" skipTo={{ h:0, m:22, s:51 }} />
 
 :::
 
@@ -309,12 +309,17 @@ After performing slant boost, a few crouch kicks off the walls will allow you to
 
 ### No Prespeed
 
+<YouTube youTubeId="UC3IFlIfjyI" skipTo={{ h:0, m:13, s:7 }} />
+
 :::
 
 :::diffm
 
 ### Prespeed
-
+<!-- 
+I think this is referencing this strat but I'm not sure: 
+<YouTube youTubeId="UC3IFlIfjyI" skipTo={{ h:0, m:23, s:34 }} />
+-->
 [idk if medium or hard difficulty i never bothered to learn this one -mats]
 
 :::

--- a/docs/tutorials/any-percent/02-bt-7274.mdx
+++ b/docs/tutorials/any-percent/02-bt-7274.mdx
@@ -173,7 +173,7 @@ Important to both Circle room and double wallkick (with the former being the mor
 
 ### Slant Boost
 
-On the second to last platform before the slant, sprint off of the right side (do not jump) and strafe to the right, potentially holding back for a short period of time to land close to the beginning of the slant. Jumping off with the correct timing should yield ~60km/h and you can then do an early double jump and tapstrafe around the corner. You should keep enough speed to clear the gap on the left side, skipping the intended wallrunning segment. Pull a grenade right before you land from the double jump and throw it just before it detonates, it should kill all three grunts and allow you to insert the battery, if not finish off whichever grunts remain with the EVA-8 and proceed to the next segment.
+<YouTube youTubeId="RbECuIMOKNg" skipTo={{ h:0, m:16, s:9 }} />
 
 :::
 

--- a/docs/tutorials/any-percent/02-bt-7274.mdx
+++ b/docs/tutorials/any-percent/02-bt-7274.mdx
@@ -37,6 +37,7 @@ At the beginning of the level after the first cutscene, Cooper is without his ju
 
 ### Frag
 
+<YouTube youTubeId="UC3IFlIfjyI" skipTo={{ h:0, m:19, s:17 }} />
 :::
 
 ## 18-hour-cutscene

--- a/docs/tutorials/any-percent/02-bt-7274.mdx
+++ b/docs/tutorials/any-percent/02-bt-7274.mdx
@@ -123,6 +123,7 @@ Important to both Circle room and double wallkick (with the former being the mor
 
 ### Circle Room Skip Advanced
 
+<YouTube youTubeId="UC3IFlIfjyI" skipTo={{ h:0, m:15, s:0 }} />
 :::
 
 


### PR DESCRIPTION
This isn't an exhaustive list of all strats covered in blaidans tutorials. There are some cases where I'm not knowledgeable enough to feel like I can confidently add stuff and in some cases the relevant information is split between beginner/intermediate which makes it hard to add a single video which covers everything needed.

A second opinion might also be needed on the 'No Prespeed' and 'Prespeed' sections of the outro. I've added clips with what I assume is meant to be the easy/intermediate version but you might want to have a look just to make sure it's the strats that you had in mind when you created the sections.

This is also a bit of a bigger PR so it might need to be squashed to not clog the commit history