### PR TITLE
[BnR] Structure the Big Door section into prespeed and slingshot

### DIFF
--- a/docs/tutorials/any-percent/03-blood-and-rust.mdx
+++ b/docs/tutorials/any-percent/03-blood-and-rust.mdx
@@ -94,17 +94,44 @@ When doing Instant Disembark, you will have to fight Kane with Expedition due to
 
 ## Big door
 
-- normal slide
+### Prespeed
 
-- Frag strat
+:::diffm
 
-- Different Prespeeds with or w/o frag
+### Crouchkick Preespeed
+
+<YouTube youTubeId="cYF3sqGzpmM" skipTo={{ h:0, m:11, s:3 }} />
+
+:::
+
+:::diffh
+
+### Frag Preespeed
+
+:::
+
+<!--- Please find a better name for this -->
+### Slingshot Area 
+
+:::diffe
+
+### Basic Route
+
+<YouTube youTubeId="cYF3sqGzpmM" skipTo={{ h:0, m:3, s:58 }} />
+
+::: 
+
+:::diffm
+
+### Slingshot
+
+<YouTube youTubeId="cYF3sqGzpmM" skipTo={{ h:0, m:11, s:13 }} />
+
+::: 
+
 
 ## Grunt hallways
 
-- Slingshot [?]
-
-[some strats are missing i think but i forgor -mats]
 
 ## Sludgefall
 


### PR DESCRIPTION
This is a bit of a weird one. On one hand it feels like it would be best to have the prespeed separate from the slingshot area since it's totally independent on it and there's a bunch of different variations. On the other it makes it a really short segment and makes it almost feel a bit to spread out. 

Anyhow, this is my attempt at making sense of it. It moves slingshot to the big door section and splits big door into 'prespeed' and 'slingshot area'. This makes it so that there can be a different set of strats for each since they  don't influence each other too much.

I'm very much open to suggestions though so just lmk and i'll see if i can throw some stuff around before you merge.

(btw there should probably be a better name for the section than a vague 'slingshot area' but I have no idea if there is a proper name for that segment so i'll leave it to people who know more than me.)