### PR TITLE
[Knowledge Base] Port glossary from google doc

### DIFF
--- a/docs/knowledge-base/contribute/_category_.json
+++ b/docs/knowledge-base/contribute/_category_.json
@@ -1,6 +1,6 @@
 {
   "label": "Contribute",
-  "position": 2,
+  "position": 3,
   "link": {
     "type": "generated-index",
     "description": "Guides on how to set up your environment so you can add your own tutorials"

--- a/docs/knowledge-base/glossary/TITANFALL 2 Speedrun Glossary.md
+++ b/docs/knowledge-base/glossary/TITANFALL 2 Speedrun Glossary.md
@@ -1,0 +1,524 @@
+# TITANFALL 2 Speedrun glossary
+
+## INTRODUCTION:
+
+Welcome to the Titanfall 2 Speedrun glossary\! This is a list of every movement trick in the game, as well as a list of common level-specific terms you’ll hear runners use a lot. If you have a question about a trick you don’t see listed, let us know in #wiki in the Titanfall 2 Speedrunning Discord. Cheers\!
+
+## MOVEMENT TRICKS:
+
+### JUMP AND AERIAL MECHANICS
+
+**Air strafe** \-
+A technique used for aerial movement. By holding left or right in the air and moving your camera accordingly, you can turn corners, jump long distances, and increase your aerial velocity. If you’ve played/ran a Source game before, this is almost exactly the same. Titanfall 2 runs on a modified version of Source.
+
+**Strafe lurch** \-
+A sudden aerial movement that occurs on directional keyboard inputs that causes the player to “lurch” in the pressed direction if pressed within .5 seconds of jumping that generally results in a loss of velocity depending on the timing of the lurch.
+
+**Tap strafe** \-
+An extension of traditional air strafing. Refers to rapidy tapping W (or “forward”) shortly after jumping/double jumping while holding a strafe input to stack strafe lurches and make sharp turns. Only possible on PC.
+
+**Fzzy strafe** \-
+Similar to tap strafing, but relies on rapidly tapping left or right inputs rather than tapping forward during a strafe. Fzzy strafing essentially stacks strafe lurches over and over to allow for very sharp corners at the cost of significant speed. Only possible on PC.
+
+**Spam strafe** \-
+A sort of combination of fzzy/tap strafing; is performed by spamming directional inputs in rapid succession to achieve a similar, but usually sharper, movement to fzzy & tap strafing. Only possible on PC.
+
+**Alternating tap strafing (alt-tapping):**
+A kind of hybrid form of lurched strafing that alternates forward and lateral inputs while specifically allowing them to overlap to achieve lurch at a more rapid frequency than traditional tap strafing.
+
+**No-lurch (prefix, NL)** \-
+aka “**Lurchless.**” General term used to describe tech for keyboard players that removes incurring strafe lurch after a jump for a plethora of different purposes. Controller moves without lurch by default.
+
+**Double jump (DJ)** \-
+A second jump that can be used after any jump or contact with the wall/ground.
+
+- **No-lurch double jump (NLDJ):** A double jump variation that removes suffering a strafe lurch, performed by strafing in a direction and pressing the opposite movement direction and double jumping at the same time, then releasing that direction to continue the strafe.
+
+- **Side jump (SJ)**: A double jump used when holding left or right; provides heavy lateral momentum.
+
+- **Spring jump**: Refers to a trick performed by doing two tick-perfect jump inputs in quick succession, resulting in a very large double jump.
+
+**Moon Boots (MB)** \-
+By disembarking from Brute/Northstar during their Flight ability, the player's gravity is reduced by \~15%. This makes Cooper very floaty and allows for extremely long jumps and tricks (see: "Super Fastball" in the Beacon ch. 3 tab).
+
+### GROUND MECHANICS
+
+**Slideboost (SB)** \-
+After meeting a certain minimum velocity, holding crouch and sliding will give you a considerable speed boost.
+
+**Slideboost timer** \-
+After performing a slideboost, there is a brief delay (\~3 seconds) before you may achieve the boost again. Contact with a wall can usually reset the timer.
+
+**Slidehop** \-
+The most basic movement mechanic used throughout the run. Performed by jumping, holding crouch, and jumping again every time you land to negate ground friction slowdown.
+
+**Extended slidehop** \-
+Refers to extending a slide before the next jump in a slidehop sequence, which gives you increased height on that jump.
+
+**Bunnyhop (bhop)** \-
+Similar to slidehopping but performed from a standing position. Extremely similar to bhopping found in various other games. Has a tighter execution window than slidehopping.
+
+**Half slide** \-
+A niche tech performed by pressing crouch right before you hit the ground, essentially allowing slides from a “standing” position.
+
+**Slant boost** \-
+Performed by hitting a sharp downward slope at a specific point/angle (changes depending on the slope/hill) to achieve a significant boost.
+
+**No-lurch jump start (NLJS)** \-
+Refers to a jump, generally at the beginning of a slidehop string, without strafe lurch. Performed by holding forward, left, and right, then letting go of forward and a lateral direction and strafing.
+
+**Circle jump** \-
+Refers to starting a jump and strafe by running diagonal and holding forward and a strafe key, then immediately beginning the strafe after the jump and releasing the forward input. Not a true circle jump in comparison to other Source/Quake engine games.
+
+**Superglide** \-
+An instant slideboost achieved by pressing sprint, crouch, and jump while leaving a fixed animation such as a mantle or cutscene.
+
+### WALL MECHANICS
+
+**Wall jump** \-
+A simple jump performed during a wallrun.
+
+**No-lurch Wall Jump (NLWJ):** \-
+A technique that allows you to jump from walls without suffering strafe lurch. Performed by holding a lateral direction as well as forward when you jump from a wall, then releasing forward and strafing in the held direction. Used for certain setups for long distance jumps like Kill Room or Heatsink skip.
+
+**Wall bump** \-
+Performed by holding crouch as you touch a wall. Gives you a small "bump" upward and refreshes your double jump.
+
+**Wall kick (WK)** \-
+An instant jump upon contact with a wall that can provide a massive speed boost. There are three different tick windows in which you can perform a wall kick:
+
+- **1 tick**: Generally referred to as "firstie," this is a “frame-perfect” WK that gives the fastest and largest speed boost of them all.
+
+- **2 to 3 ticks**: Provides a smaller speed boost than a firstie, but is still a significant boost. This is the window you'll want to get consistent with, as chaining multiple 3-framers together can lead to massive speeds.
+
+- **4 to 5 ticks**: The latest window you can technically perform a WK. The speed boost from a 5 frame WK is marginal but you still aren't losing any speed due to contacting the wall.
+
+- **No-lurch wall kick (NLWK/Strafe kick):** Allows for performing wall kicks without suffering strafe lurch. Performed by holding a lateral direction and forward before contacting a wall, and then performing the wall kick.
+
+- **Neutral strafe kick (NSK):** Performed by holding all three primary directional inputs (left/right/forward) before doing a wall kick. Allows for more freedom in terms of strafe direction following a wall kick while still not incurring lurch.
+
+- **Blind wall kick:** Refers to having to perform a wall kick without the camera tilt and “lean-in” animation that is normally present before a wall kick, usually due to the angle a wall is placed or sitting at.
+
+- **Double wall kick:** In Titanfall 2, you can only regrab a wall once you're at a lower vertical position than when you originally grabbed it. “Double wall kick” refers to performing two wall kicks on the same wall by taking advantage of the aforementioned mechanic.
+
+- **Crouch kick**: Effectively a wall kick-end boost. Performed by pressing crouch and jump at the same time immediately upon contact with a wall for a potent speed boost.
+
+**Edge boost** \- Performed by jumping at the "edge" or corner of a wall during the last few ticks in which you have contact to achieve a boost.
+
+- **Crouched edge boost (cEB):** Effectively an end boost-edge boost. Achieved by pressing crouch and jump at the same time when jumping at the “edge” of a corner or wall.
+
+**End boost** \-
+Performed by jumping at the very end of the wallrun animation. There is a set amount of time in which you can cling to the wall during a wallrun. If you jump at the very end of that animation, you receive the same speed boost as an edge boost.
+
+- **Forced end boost (FEB):** Performed by holding away from the wall you are running on and jumping during the window in which you are leaving the wall. Allows for end boosts well before the standard time required to achieve one.
+
+- **Lurchless/No-lurch forced end boost (FEBL):** A variation of a FEB that prevents you from suffering strafe lurch via a press inward toward the wall right before forcing yourself away.
+
+- **Crouched forced end boost (cFEB)**: A forced end boost achieved by pressing crouch and jump at the same time while wallrunning. More powerful than a standard FEB. Can be performed lurchless by holding in toward the wall before the jump.
+
+**Wall jump ladder** \-
+Performed by jumping between two perpendicular or opposite-facing walls in quick succession to clear large vertical distances quickly.
+
+**Bump launch** \-
+Performed by placing yourself in a corner, holding crouch, and mashing jump. The rapid series of inputted wallbumps and jumps launches the player upward.
+
+**Banana peel timer** \-
+Refers to lack of wall-friction the player experiences after performing a damage boost. The length of the timer is dependent on the strength of the damage boost itself.
+
+### TITAN MECHANICS
+
+**Swap reloading** \-
+Performed by bringing up the Titan loadout menu, and quickly swapping from one loadout and then back to the one you had previously selected. Allows for faster reload times than waiting out the reload animation on most Titans.
+
+**Tacticancel** \-
+Titans that have a shield or block tactical ability (Exhibition, Ronin, Scorch, etc) can quickly use that ability after a swap to their specific loadout to cancel the animation where BT brings up gun, allowing you to shoot earlier.
+
+**Disembark jump (DEJ)** \-
+Performed by pressing jump toward the end of the Titan disembark animation (around when Cooper's feet touch the floor of the cockpit). When done correctly, you'll launch into the air directly from BT's cockpit.
+
+- **No-lurch disembark jump:** A disembark jump without incurring strafe lurch. Performed by holding forward, left, and right, then letting go of forward and a lateral direction and strafing.
+
+**Disembark boost** \-
+Performed by pressing crouch and holding forward as you disembark. When done correctly you'll receive a considerable horizontal speed boost that can be easily transitioned into a slidehop. You cannot disembark boost while using a Titan dash, you must be sprinting.
+
+- **No-lurch disembark boost:** A disembark boost without incurring strafe lurch. Performed by holding forward and a strafe key, then immediately beginning the strafe and releasing the forward input after a boost.
+
+**Disembark clip** \-
+Performed by using Brute/Northstar's Flight ability to reach/stand on unintended locations, then disembarking. Arguably the most consistent out-of-bounds method.
+
+**Crouch Dash** \-
+Performed by immediately holding crouch following a dash. This causes BT to retract his legs, which allows you to travel further through the air following a dash without being affected by ground friction. Best used when dashing off of a raised surface like a ledge or bump.
+
+**No-lurch Titan dash (NLTD)** \-
+Refers to a Titan dash, usually off a ledge and into the air, that doesn’t suffer strafe lurch. Performed by holding forward, left, and right, then letting go of forward and a lateral direction and strafing.
+
+**Core/Health Glitch** \-
+Performed by connecting to multiplayer, starting a private match, and adjusting the game settings to 500% Core Meter Gain & 500% health. By quitting the lobby and then quitting straight to main menu, you can keep the 500% modifiers in the campaign mode.
+
+**Hover strafing** \-
+Performed by holding forward and either left/right during Northstar or Brute’s hover ability, giving a small speed increase.
+
+**Flame trap duping (trap duping)** \-
+Using scorch; Refers to a tech used to ignite flame traps multiple times over using very specific methods such as looking straight up in the air and activating flame wall while standing over a flame trap.
+
+### DAMAGE AND EXPLOSION BOOSTS
+
+**Damage boot** \-
+Generally refer to any sort of speed boost as a result of taking damage from a variety of different sources.
+
+- **\[pilot, melee\]**: Getting hit by a melee/other physical attack from a Prowler or any IMC unit (grunt, spectre, stalker, reaper), can result in a large speed boost in the direction in which the enemy is facing you.
+
+- **\[pilot, projectile\]**: Getting hit by any projectile (NOT HITSCAN) will give you a small boost depending on the direction you're hit from. This includes, among other things: Kraber shots, LSTAR/Mastiff/Mozambique projectiles, Drone shots, etc.
+
+- **\[Titan, melee\]**: If you are hit with a Titan melee attack while your shield is down, you'll receive a very large burst of speed in the direction the enemy was facing.
+
+- **\[Titan, projectile\]**: This boost also requires your shield to be down, and functions the same as the pilot projectile boost, but with the following weapons, among others: Northstar shot, Ronin shot, Tone missiles/40mm, Ion splitter rifle shot, Legion power shot, etc.
+
+**EPG boost** \- Refers to using the EPG to damage boost, usually performed by flicking it behind you.
+
+**Softball boost** \- Refers to using the softball grenade to damage boost.
+
+**Frag boost \[Gauntlet version\]** \- Performed by cooking a frag grenade and letting it explode in your hand, giving the player a massive speed boost depending on your jump/wall kick timing.
+
+**Frag boost \[standard version\]** \- Performed by cooking a frag grenade, dropping it, and jumping just as it explodes outside of the kill-radius. The resulting explosion gives a large speed boost.
+
+**Gravity star boost (gstar)** \- Refers to throwing a gravity star at a surface and jumping as close to the star as possible right as it explodes.
+
+**Satchel boost** \- Refers to attaching a satchel charge to a surface and then triggering the explosion right as you jump outside of the kill radius.
+
+## **COMMON LEVEL-SPECIFIC TERMS AND TRICKS:**
+
+_Most all of the following terms, names, and tricks can be found with video in the doc._
+
+### **THE PILOTS GAUNTLET:**
+
+**Wallrun Skip** \- Performed by gaining a large amount of speed via strafing at the beginning of the gauntlet, then clearing the gap where Lastimosa tells you to wallrun.
+
+**Reload skip** \- Performed at the shooting range by reloading the pistol and picking up the R201 during the pistol reload animation. This skips reloading the R201.
+
+**Broken Gauntet** \- Refers to moving through the Gauntlet strating gate too quickly, resulting in the Gauntlet itself not starting. Some runners attempt to reach the platform where FS-1041 is called down without being teleported by Lasitmosa when this happens.
+
+### **BT-7274:**
+
+**18hr Cutscene** \- Infamous cutscene named for its dialogue that occurs at the beginning of BT-7274 and introduces the Apex Predators.
+
+**18hr Bypass** \- A savefile mod runners use to bypass the 18hr cutscene. The cutscene is skipped and all skipped time is re-injected into the timer.
+
+**Death river** \- A very difficult section/route toward the beginning of the level after your first contact with IMC grunts in which you must jump over a large river gap.
+
+**Prowler pad** \- The small pad with two prowlers after death river where you get your double jump for the first time.
+
+**Battery 1** \- General reference to the entire segment of BT-7274 that occurs between putting on the helmet and retrieving the first battery.
+
+**River jump** \- A precise jump over the river following installing the first battery in BT.
+
+**Boom boom river jump (BBRJ)** \- A version of river jump found by sDeception\_ that uses frag boosts.
+
+**Josh Frag** \- A frag boost after river jump that gives you a large amount of speed across a big gap and into ravine. Named after runner Joshwa04, who routed the boost.
+
+**Ravine** \- The section after River jump that requires several wallkicks in a row, generally considered one of the hardest sections in the level.
+
+**Encampment** \- The segment of BT following ravine with a couple small IMC structures/bases and several grunts.
+
+**Vents** \- The tight series of vents before you grab the second battery.
+
+**Battery 2** \- General reference to the entire segment of BT-7274 that occurs between installing the first battery and retrieving the second.
+
+**DMR Strat** \- Refers to a difficult 3rd battery clear strat using the rock arch and a DMR.
+
+### **BLOOD AND RUST (BNR):**
+
+**Nessie Vault** \- A complex easter egg on Blood and Rust that requires finding three sake bottles and jumping into a sludge pool.
+
+**Tone slide** \- A skate over the top of a Tone that drops in during the beginning segment of the level.
+
+**Early Disembark** \- Refers to the strat used in ILs and in high level full-game runs where you disembark shortly after grabbing Tone and make your way to the airlock on foot.
+
+**Barry, the Bridge Guardian** \- Nickname for the grunt that stands on the bridge before the long sludge slide.
+
+**Barry Blast** \- Name for the frag boost strat that launches you over Barry and down the slide.
+
+**Sniper Canal** \- The "canal" following the long slide after entering the sludge facility that is filled with Kraber-carrying grunts.
+
+**Clean hallways** \- Performed by slidehopping through the tight hallways following Sniper Canal without bonking or hitting any debris.
+
+**Slingshot** \- Refers to a strat after the large door slides open that uses several lurchless wall jumps & kicks to build high speed heading into grunt hallways.
+
+**Grunt hallways** \- The segment following the large door opening that features 3 tight hallways littered with enemy stalkers and grunts.
+
+**Pipe climb** \- A difficult climb up to the side sludge fight room that involves 14 jumps when done optimally.
+
+**Pipe bump** \- A bump launch strat used in the pipe climb segment.
+
+**Pipes/Pipe hallways** \- The last segment before sludge skip. A very difficult, tight segment through several very tight/narrow hallways with various pipes and tubes along the walls and floor.
+
+**Sludge skip** \- A tricky skip that skips the entire sludge fight before you fight Kane.
+
+### **INTO THE ABYSS (ABYSS, ITA):**
+
+#### _Chapter 1_
+
+**Wall Boost** \-
+A large speed boost from one of the assembly line walls before door clear.
+
+**Door clear** \-
+The brief fight toward the end of the chapter in which you must kill three Titans to open a door.
+
+#### _Chapter 2_
+
+**Platform launch/Swaginoz** \-
+Performed once you reach the beginning of the assembly line by jumping off the platform as it launches forward, and using that speed to carry you across the entire gap.
+
+**Toldspice route** \-
+A safe route through ItA2 that requires you to traverse a rock wall around the far right side of the map.
+
+**Dome Launch** \-
+A massive momentum boost from one of the assembly line arms that takes you from the bottom of the assembly line to the dome trigger.
+
+**Dome skip** \-
+An out of bounds skip that skips the entire dome fight.
+
+**Abyss 2 bounty** \-
+Refers to the bounty placed on finding a skip that skips the entirety of Abyss 2\.
+
+#### _Chapter 3_
+
+**Cylinder skip** \-
+A strat in which you activate the containment towers ("cylinders") and hop inside the tower before it rotates.
+
+**Decep Caverns** \-
+Refers to a difficult cycle-based strat through the caverns following Cylinder Skip that was innovated by sDeception.
+
+**Ash skip** \-
+An out of bounds skip that skips the Ash fight via disembark clipping.
+
+**Hoverless** \-
+After disembark clipping out of bounds for Ash skip, Hoverless is performed by running at the large set of pipes on the right at an angle and climbing to the top of them without using hover.
+
+### **EFFECT AND CAUSE (ENC):**
+
+#### _Chapter 1_
+
+**Rock boost** \-
+A very precise slant boost performed after you drop from the upper section of the research facility.
+
+**Early Zip** \-
+Refers to a trick where we climb up on the side of the research facility and make an early leap toward where BT throws the zipline.
+
+**Faster than Light** \-
+A difficult strat that uses a laser-grid damage boost to launch you through Skybridge without getting caught in the timeswaps.
+
+**Skybridge** \-
+A frustrating section at the end of EnC1 with heavy softlock potential.
+
+#### _Chapter 2_
+
+**Joshhop** \-
+A small edge boost after the first button press of the level routed by Joshwa04.
+
+**Elevator** \-
+The climb up the elevator shaft following the first few hallways.
+
+**Anderson 1/2** \-
+Refers to either the first or second “Anderson Rooms” that break up the level where Anderson’s hologram logs play out.
+
+**Cryostorage** \-
+The section right before Hell Room with a number of tight jumps and corners.
+
+**Hell Room** \-
+Named for its colour and difficulty, one of the hardest rooms in the game with a very tight optimal route and high death potential.
+
+**Hell Room zipless (HRZ)** \-
+A very difficult strat for Hell Room that requires the runner to generate enough speed using two frag boosts to skip grabbing the zipline.
+
+**Snuggle slide** \-
+A strat at the end of Hell Room that uses the large extending bridge to launch the player down the hallway toward the drop down the vents.
+
+#### _Chapter 3_
+
+**Timestop** \-
+A very cool trick in that exploits the way the level is constructed to make it appear as though time has stopped to clip through walls. See "Timestop explanation and showcase" in the Effect and Cause ch. 3 tab of the compendium.
+
+**Timestop reverse trigger order (RTO)** \-
+Refers to a strat in which you boost yourself off of the laser grid after activating Timestop at the terminal and activate the level triggers in reverse order.
+
+**Ship Skip** \-
+A very difficult skip during the frozen time segment at the end of ENC3 which skips clamoring through the ship after the zipline by wall kicking off a piece of floating debris.
+
+### **THE BEACON (b):**
+
+#### _Chapter 1_
+
+**Dialogue skip** \-
+Performed by running far ahead of BT and clearing the Stalkers clinging to the control room and then returning to BT. The dialogue between Cole and BT then quickly cycles.
+
+**Beacon 1 clip** \-
+An infamous clip found by a non-runner in which he found a way to clip inside the top of the control room and navigate to the trigger for the next level. We have never been able to reproduce as there's no footage of the actual clip, just what happened after.
+
+#### _Chapter 2_
+
+**Kill Room Skip (KRS)** \-
+A very precise damage boost \+ wall kick/edge boost that sends you across a large gap in Beacon ch.2 and entirely skips the Kill Room segment.
+
+**Kill room** \-
+A small room after the first couple hallway sections in which you must kill a certain number of enemies as fast as possible to open a door.
+
+**Arc tool room** \-
+The room where you obtain the Arc tool from the MRVN.
+
+**Early Fan Cycle (EFC)** \-
+Refers to a strat that incorporates a launch off the fan in the Arc tool room by jumping into it before turning it off.
+
+**Second fan launch** \-
+The second fan jump in the level that launches you straight up.
+
+**Mayo bonk** \-
+Refers to a strat found by Cash Mayo that allows you to bonk one of the lower ceilings after the second fan launch.
+
+**Heatsink skip** \-
+A difficult, air strafe-heavy skip that skips traversing one of the Heatsink rooms.
+
+- **RSHS:** “Right-side Heatsink.” A more difficult variation of Heatsink that uses a grate on the right side of the room, rather than the door on the left.
+
+- **Frag Heatsink:** Refers to the strat that uses a frag grenade to clear the gap.
+
+- **Softball Heatsink:** Refers to the strat that uses a softball boost to clear the gap.
+
+**Grate mantle** \-
+An infamous 1 frame trick following Heatsink skip where you can actually mantle the grate that opens before the wind tunnel.
+
+**Corner cut** \-
+Refers to a strat that uses fzzy or tap strafing to skip a small portion of the wind tunnel.
+
+**Fast fans** \-
+A difficult trick that requires you to carry your momentum from the fan launch and wall kick off the first fan at the end of the level, skip jumping off the second fan, and then wall kick off the third fan.
+
+- **Fzzy fans:** A faster variation of fast fans that doesn’t turn off the first fan.
+
+- **Breezy fans:** An even faster and more difficult version of fzzy fans that only turns off the third fan.
+
+**Stair slide** \-
+By mashing jump at a certain cadence you can "slide" up the staircase toward the next level trigger.
+
+#### _Chapter 3_
+
+**Super fastball (SFB)** \- A massive, difficult route/trick in which you activate moon boots, and then hold jump as BT throws you. Using wall kicks and air strafing you can make it all the way to the final section before the module grab without losing any speed.
+
+- **Super fastball deluxe:** A route variation of Super Fastball that picks up gravity starts in the middle of the route, rather than at the end, and allows you to get to the dish module much earlier.
+
+**Super curveball (SCB)** \- The more difficult, All Helmets variant of Super Fastball.
+
+**Terminal skip** \- A gravity star boost you perform immediately after picking up gravity stars near the dish containing the module. Skips using the terminal to move the dish.
+
+**Zipless** \- Technically only refers to skipping the zipline following the segment in which you return to BT. However, it is generally used to refer to the entire route in which you do a second gravity star boost after grabbing the dish module followed by a wall kick that carries you over to the return route to BT.
+
+- **Hyper Zipless:** A fun nickname for the stylish Zipless variation that uses a platform launch in the return segment to give you a gigantic vertical boost.
+
+- **PZip:** “Poverty zipless.” Nickname for the slower, safer zipless setup.
+
+**Dish fight** \- Refers to the fight following returning to BT with the module.
+
+**Dish skip** \- An early climb to the top of the dish that skips BT throwing you.
+
+**Elmo clip** \- A strat that clips BT both into and out of the Beacon hub room that instantly teleports him to the top of the elevator.
+
+### **TRIAL BY FIRE (TBF):**
+
+**Sword block strat** \-
+Refers to the strat at the beginning of Trial by Fire in which you use Ronin’s Sword Block ability to block the gun turret damage and walk through the walls.
+
+**Elevator Hover** \-
+Refers to using Brute’s Hover ability to skip waiting for the elevator to rise all the way to the top after escorting Sarah.
+
+### **THE ARK:**
+
+**Barker skip** \-
+A very difficult skip at the beginning of the Ark in which we use a frag boost to jump from Barker's ship to the 6-4.
+
+**6-4 skip (early 6-4)** \-
+An early jump from the 6-4 to the IMC gunship that skips waiting for the 6-4 to get into position and set up for a jump.
+
+**Third battery clear** \-
+The term generally used to refer to clearing the third gun battery before regrouping with the 6-4.
+
+**Early Sarah** \-
+A trick performed after clearing the 3rd gun battery in which you jump on top of Sarah's ship and then over to the hangar as she's rising up to help the 6-4.
+
+**Room clear** \-
+Refers to killing several sets of enemies after reaching the hangar as fast as possible.
+
+**Ghost ship** \-
+A very rare and strange bug where Barker's ship flies through the control room after Barker drops BT off.
+
+**Viper Zerg** \-
+Refers to the Viper fight strat in which you kill Viper first and use core on the remaining two Titans.
+
+### **THE FOLD WEAPON (FW):**
+
+**Flotsa Strat** \-
+A strat in which after regaining control of Cooper you walk directly back into the fire and almost die, then walk out. Saves having to wait for BT to talk to you.
+
+**Datacore** \-
+Generally refers to the entire segment spanning from the SERE kit retrieval to calling down a new Titan chassis.
+
+**Cooling vents** \-
+Refers to a wall kick heavy segment in the middle of the Datacore segment.
+
+**Door skip** \-
+Skips having to wait for enemies to open the door before the final run to Slone fight by disembarking from BT and clipping through the top of the door.
+
+**Triple core Slone** \-
+Refers to a very difficult Slone fight strat that uses 3 cores to complete the fight quickly and setup for Andyshot and Fold Weapon Precharge.
+
+**AndyShot** \-
+A cutscene skip performed by using Sword Core immediately before pulling the Ark Injector. Allows you to have your gun out when Blisk walks over your Titan. Shooting Blisk kills him and instantly skips his dialogue.
+
+**Fold Weapon Precharge (Precharge)** \-
+Refers to completing Slone fight fast enough before the “97%” dialogue in the Fold Weapon room, which causes the Fold Weapon to remain charged after BT climbs in and skips the charging sequence.
+
+**Fzzy Slone** \-
+Refers to a Slone fight strat that manipulates Slone’s animations in order to cause the Reapers in Phase 2 to drop a few seconds sooner.
+
+**Zweekscape** \-
+Refers to a route for the “escape” sequence routed by Zweek that takes advantage of the various moving rocks and platforms.
+
+## **MISCELLANEOUS OTHER TERMS:**
+
+**Quickswap** \-
+Performed by crouching in the middle of a weapon swap animation to swap between weapons faster.
+
+**Glitched state** \-
+Refers to the player state in which the player seemingly skews through walls. It is not currently known how this state is achieved and has only ever been achieved by chance.
+
+**Soft drop** \-
+Performed by using weapon swap while holding a frag to drop it beneath you, rather than throwing it.
+
+**Coyote time** \-
+The number of frames in which you can still execute a jump after running off a ledge.
+
+**Any%** \-
+Refers to completing a game to “any percent of completion” as quickly as possible. I.e., completion percentage is irrelevant, just complete the game as quickly as possible.
+
+**All Helmets** \-
+A category in which you must collect all the pilot helmets hidden throughout the game and complete it as quickly as possible.
+
+**No Cutscenes (NCS)** \-
+A PC-only speedrun category that uses premade savefiles to skip the majority of the unskippable cutscenes and dialogue present in the game’s campaign. NCS categories exist for both Any% and All Helmets.
+
+**Pilot’s Challenge** \-
+A short category in which the runner must complete 3 of the games fastest and most pilot-movement intensive levels in the game: Blood and Rust Effect and Cause ch.2, and Beacon ch. 2\.
+
+**IL** \-
+“Individual Level.” Generally refers to running single levels in the game, rather than full runs.
+
+**TAS** \-
+“Tool Assisted Speedrun.” Generally refers to using external tools such as slow-mo, frame advance, etc. to play a speedrun at a theoretically perfect level.
+
+**Speedmod** \-
+A custom.cfg mod that changes many aspects of Titanfall 2’s movement.
+
+**DAADIE** \-
+An acronym used to refer to “Digital to Analog/Analog to Digital Input Emulation,” which is a banned form of input emulation that allows for keyboards to perform movement without strafe lurch.
+
+**Icepick** \-
+A mod for Titanfall 2 that allows for custom gauntlet creation, among other things.

--- a/docs/knowledge-base/glossary/TITANFALL 2 Speedrun Glossary.md
+++ b/docs/knowledge-base/glossary/TITANFALL 2 Speedrun Glossary.md
@@ -1,10 +1,10 @@
 # TITANFALL 2 Speedrun glossary
 
-## INTRODUCTION:
+## INTRODUCTION
 
 Welcome to the Titanfall 2 Speedrun glossary\! This is a list of every movement trick in the game, as well as a list of common level-specific terms you’ll hear runners use a lot. If you have a question about a trick you don’t see listed, let us know in #wiki in the Titanfall 2 Speedrunning Discord. Cheers\!
 
-## MOVEMENT TRICKS:
+## MOVEMENT TRICKS
 
 ### JUMP AND AERIAL MECHANICS
 
@@ -23,7 +23,7 @@ Similar to tap strafing, but relies on rapidly tapping left or right inputs rath
 **Spam strafe** \-
 A sort of combination of fzzy/tap strafing; is performed by spamming directional inputs in rapid succession to achieve a similar, but usually sharper, movement to fzzy & tap strafing. Only possible on PC.
 
-**Alternating tap strafing (alt-tapping):**
+**Alternating tap strafing (alt-tapping)** \-
 A kind of hybrid form of lurched strafing that alternates forward and lateral inputs while specifically allowing them to overlap to achieve lurch at a more rapid frequency than traditional tap strafing.
 
 **No-lurch (prefix, NL)** \-
@@ -78,7 +78,7 @@ An instant slideboost achieved by pressing sprint, crouch, and jump while leavin
 **Wall jump** \-
 A simple jump performed during a wallrun.
 
-**No-lurch Wall Jump (NLWJ):** \-
+**No-lurch Wall Jump (NLWJ)** \-
 A technique that allows you to jump from walls without suffering strafe lurch. Performed by holding a lateral direction as well as forward when you jump from a wall, then releasing forward and strafing in the held direction. Used for certain setups for long distance jumps like Kill Room or Heatsink skip.
 
 **Wall bump** \-
@@ -103,9 +103,11 @@ An instant jump upon contact with a wall that can provide a massive speed boost.
 
 - **Crouch kick**: Effectively a wall kick-end boost. Performed by pressing crouch and jump at the same time immediately upon contact with a wall for a potent speed boost.
 
-**Edge boost** \- Performed by jumping at the "edge" or corner of a wall during the last few ticks in which you have contact to achieve a boost.
+**Edge boost** \-
+Performed by jumping at the "edge" or corner of a wall during the last few ticks in which you have contact to achieve a boost.
 
-- **Crouched edge boost (cEB):** Effectively an end boost-edge boost. Achieved by pressing crouch and jump at the same time when jumping at the “edge” of a corner or wall.
+- **Crouched edge boost (cEB)** \-
+  Effectively an end boost-edge boost. Achieved by pressing crouch and jump at the same time when jumping at the “edge” of a corner or wall.
 
 **End boost** \-
 Performed by jumping at the very end of the wallrun animation. There is a set amount of time in which you can cling to the wall during a wallrun. If you jump at the very end of that animation, you receive the same speed boost as an edge boost.
@@ -138,8 +140,8 @@ Performed by pressing jump toward the end of the Titan disembark animation (arou
 
 - **No-lurch disembark jump:** A disembark jump without incurring strafe lurch. Performed by holding forward, left, and right, then letting go of forward and a lateral direction and strafing.
 
-**Disembark boost** \-
-Performed by pressing crouch and holding forward as you disembark. When done correctly you'll receive a considerable horizontal speed boost that can be easily transitioned into a slidehop. You cannot disembark boost while using a Titan dash, you must be sprinting.
+- **Disembark boost:**
+  Performed by pressing crouch and holding forward as you disembark. When done correctly you'll receive a considerable horizontal speed boost that can be easily transitioned into a slidehop. You cannot disembark boost while using a Titan dash, you must be sprinting.
 
 - **No-lurch disembark boost:** A disembark boost without incurring strafe lurch. Performed by holding forward and a strafe key, then immediately beginning the strafe and releasing the forward input after a boost.
 
@@ -161,9 +163,12 @@ Performed by holding forward and either left/right during Northstar or Brute’s
 **Flame trap duping (trap duping)** \-
 Using scorch; Refers to a tech used to ignite flame traps multiple times over using very specific methods such as looking straight up in the air and activating flame wall while standing over a flame trap.
 
+**Infinite Flight Core (Encore)** \-
+An exploit performed by switching from brute to scorch, and immediately using the core ability. This places the flight core as your main weapon, granting access to infinite flight core rockets.
+
 ### DAMAGE AND EXPLOSION BOOSTS
 
-**Damage boot** \-
+**Damage boost** \-
 Generally refer to any sort of speed boost as a result of taking damage from a variety of different sources.
 
 - **\[pilot, melee\]**: Getting hit by a melee/other physical attack from a Prowler or any IMC unit (grunt, spectre, stalker, reaper), can result in a large speed boost in the direction in which the enemy is facing you.
@@ -186,11 +191,11 @@ Generally refer to any sort of speed boost as a result of taking damage from a v
 
 **Satchel boost** \- Refers to attaching a satchel charge to a surface and then triggering the explosion right as you jump outside of the kill radius.
 
-## **COMMON LEVEL-SPECIFIC TERMS AND TRICKS:**
+## **COMMON LEVEL-SPECIFIC TERMS AND TRICKS**
 
 _Most all of the following terms, names, and tricks can be found with video in the doc._
 
-### **THE PILOTS GAUNTLET:**
+### **THE PILOTS GAUNTLET**
 
 **Wallrun Skip** \- Performed by gaining a large amount of speed via strafing at the beginning of the gauntlet, then clearing the gap where Lastimosa tells you to wallrun.
 
@@ -198,7 +203,7 @@ _Most all of the following terms, names, and tricks can be found with video in t
 
 **Broken Gauntet** \- Refers to moving through the Gauntlet strating gate too quickly, resulting in the Gauntlet itself not starting. Some runners attempt to reach the platform where FS-1041 is called down without being teleported by Lasitmosa when this happens.
 
-### **BT-7274:**
+### **BT-7274**
 
 **18hr Cutscene** \- Infamous cutscene named for its dialogue that occurs at the beginning of BT-7274 and introduces the Apex Predators.
 
@@ -226,13 +231,19 @@ _Most all of the following terms, names, and tricks can be found with video in t
 
 **DMR Strat** \- Refers to a difficult 3rd battery clear strat using the rock arch and a DMR.
 
-### **BLOOD AND RUST (BNR):**
+**Titan Tutorial** \- The segment which follows after you embark bt where you have to kill grunts and drones using bts abilities.
+
+**No U** \- A quick setup to kill the Brute at the end of the level by using their own bullets against them.
+
+### **BLOOD AND RUST (BNR)**
 
 **Nessie Vault** \- A complex easter egg on Blood and Rust that requires finding three sake bottles and jumping into a sludge pool.
 
 **Tone slide** \- A skate over the top of a Tone that drops in during the beginning segment of the level.
 
 **Early Disembark** \- Refers to the strat used in ILs and in high level full-game runs where you disembark shortly after grabbing Tone and make your way to the airlock on foot.
+
+**Instant Disembark (Vizembark, Decepembark etc.)** \- A high level strat where you disembark immediately after loading into the level and utilize fragboosts and wall kicks to gain incredible speed.
 
 **Barry, the Bridge Guardian** \- Nickname for the grunt that stands on the bridge before the long sludge slide.
 
@@ -254,15 +265,23 @@ _Most all of the following terms, names, and tricks can be found with video in t
 
 **Sludge skip** \- A tricky skip that skips the entire sludge fight before you fight Kane.
 
-### **INTO THE ABYSS (ABYSS, ITA):**
+**Pilot Transition** \- A route where you disembark from bt after performing sludge skip and use pilot movement to navigate to the Kane fight.
+
+### **INTO THE ABYSS (ABYSS, ITA)**
 
 #### _Chapter 1_
 
 **Wall Boost** \-
 A large speed boost from one of the assembly line walls before door clear.
 
+**Vibecheck** \-
+A variant of wall boost where you don't disembark from bt.
+
 **Door clear** \-
 The brief fight toward the end of the chapter in which you must kill three Titans to open a door.
+
+**Titanless** \-
+A very difficult route where you never embark in bt and instead utilize pilot movement to clip out of bounds in order to get to the end of the level.
 
 #### _Chapter 2_
 
@@ -286,16 +305,28 @@ Refers to the bounty placed on finding a skip that skips the entirety of Abyss 2
 **Cylinder skip** \-
 A strat in which you activate the containment towers ("cylinders") and hop inside the tower before it rotates.
 
+**Cylinder skip skip** \-
+A strat where you climb up the wall in the cylinder skip room and kick of the cylinders in order to skip the cylinder skip.
+
 **Decep Caverns** \-
 Refers to a difficult cycle-based strat through the caverns following Cylinder Skip that was innovated by sDeception.
 
-**Ash skip** \-
+**Hover Ash skip** \-
 An out of bounds skip that skips the Ash fight via disembark clipping.
 
 **Hoverless** \-
 After disembark clipping out of bounds for Ash skip, Hoverless is performed by running at the large set of pipes on the right at an angle and climbing to the top of them without using hover.
 
-### **EFFECT AND CAUSE (ENC):**
+**E-smoke Ash Skip** \-
+A skip which exploits bt:s reaction to an e-smoke in order to clip through the door in the Ash fight.
+
+**DAsh Skip** \-
+A skip which uses precise movements and dashes in order to clip through the door in the Ash fight.
+
+**Pilot Ash Trigger Skip (PATS)** \-
+A difficult skip which uses high speeds and damage boosts to get into the Ash arena without triggering the fight. This leaves the door to the end level trigger open. Can be performed both with and without moonboots depending on whether or not Brute is available.
+
+### **EFFECT AND CAUSE (ENC)**
 
 #### _Chapter 1_
 
@@ -307,6 +338,9 @@ Refers to a trick where we climb up on the side of the research facility and mak
 
 **Faster than Light** \-
 A difficult strat that uses a laser-grid damage boost to launch you through Skybridge without getting caught in the timeswaps.
+
+**Faster than Time** \-
+A strat which uses an assortment of strafes, kicks and damage boosts in order to build enough sped to avoid getting caught in the timeswaps on Skybridge without using the laser-grid.
 
 **Skybridge** \-
 A frustrating section at the end of EnC1 with heavy softlock potential.
@@ -321,6 +355,9 @@ The climb up the elevator shaft following the first few hallways.
 
 **Anderson 1/2** \-
 Refers to either the first or second “Anderson Rooms” that break up the level where Anderson’s hologram logs play out.
+
+**Blender** \-
+An elaborate setup for building up pre speed when exiting Anderson 2.
 
 **Cryostorage** \-
 The section right before Hell Room with a number of tight jumps and corners.
@@ -345,7 +382,7 @@ Refers to a strat in which you boost yourself off of the laser grid after activa
 **Ship Skip** \-
 A very difficult skip during the frozen time segment at the end of ENC3 which skips clamoring through the ship after the zipline by wall kicking off a piece of floating debris.
 
-### **THE BEACON (b):**
+### **THE BEACON (b)**
 
 #### _Chapter 1_
 
@@ -387,6 +424,9 @@ A difficult, air strafe-heavy skip that skips traversing one of the Heatsink roo
 **Grate mantle** \-
 An infamous 1 frame trick following Heatsink skip where you can actually mantle the grate that opens before the wind tunnel.
 
+**Dark Slide** \-
+A strat which uses precise movement to gain incredible speed during the windtunnel. Currently the highest velocity strat in the game.
+
 **Corner cut** \-
 Refers to a strat that uses fzzy or tap strafing to skip a small portion of the wind tunnel.
 
@@ -406,6 +446,8 @@ By mashing jump at a certain cadence you can "slide" up the staircase toward the
 
 - **Super fastball deluxe:** A route variation of Super Fastball that picks up gravity starts in the middle of the route, rather than at the end, and allows you to get to the dish module much earlier.
 
+- **Hyper Fastball (HFB):** A variation of Super Fastball Deluxe that goes to the left side of the building at the end instead of the right. This allows you to keep speed all the way to the dish module.
+
 **Super curveball (SCB)** \- The more difficult, All Helmets variant of Super Fastball.
 
 **Terminal skip** \- A gravity star boost you perform immediately after picking up gravity stars near the dish containing the module. Skips using the terminal to move the dish.
@@ -416,21 +458,42 @@ By mashing jump at a certain cadence you can "slide" up the staircase toward the
 
 - **PZip:** “Poverty zipless.” Nickname for the slower, safer zipless setup.
 
+**Tesco Meal Deal** \-
+An RTO strat where you use the speed from Hyper Zipless to get to the Dish Fight platform before going back to the Milk Aisle. This removes a hidden timer which allows you to finish the Dish Fight earlier.
+
+**Cooperang** \-
+A difficult version of Tesco Meal Deal which uses a kick high up on the dish to return to the Milk Aisle.
+
+**The Milk Aisle** \-
+The circular building connected to the Dish Fight with a zipline.
+
 **Dish fight** \- Refers to the fight following returning to BT with the module.
 
 **Dish skip** \- An early climb to the top of the dish that skips BT throwing you.
 
 **Elmo clip** \- A strat that clips BT both into and out of the Beacon hub room that instantly teleports him to the top of the elevator.
 
-### **TRIAL BY FIRE (TBF):**
+### **TRIAL BY FIRE (TBF)**
 
 **Sword block strat** \-
 Refers to the strat at the beginning of Trial by Fire in which you use Ronin’s Sword Block ability to block the gun turret damage and walk through the walls.
 
+**Robcore** \-
+A strat where you disembark out of bt during Sword Block Strat in order to build up your core meter. Also allows you to pick up some frags.
+
+**Triggerless** \-
+A route which avoids a trigger that spawns enemy titans.
+
 **Elevator Hover** \-
 Refers to using Brute’s Hover ability to skip waiting for the elevator to rise all the way to the top after escorting Sarah.
 
-### **THE ARK:**
+**Lone Wolf** \-
+A titanless strat which goes from the elevator to the end of the level. Infamous for being dangerous due to the high number of enemy titans throughout the route.
+
+**Lupine Leap**\-
+A difficult RTO strat which hits the end level trigger early by jumping across the gap after the elevator.
+
+### **THE ARK**
 
 **Barker skip** \-
 A very difficult skip at the beginning of the Ark in which we use a frag boost to jump from Barker's ship to the 6-4.
@@ -447,13 +510,29 @@ A trick performed after clearing the 3rd gun battery in which you jump on top of
 **Room clear** \-
 Refers to killing several sets of enemies after reaching the hangar as fast as possible.
 
+**Ship Steer**\-
+Refers to the section where you pilot the ship before embarking onto bt. This entire section is notorious for being the home to a number of run killing bugs, most notably that the game can crash. The reason for this crash is still unknown and various methods have been tested in order to avoid it. The list includes but is not limited to:
+
+- Waiting half a second or so before interacting with/walking near the control panel
+- Having your last input steer the ship upwards
+- Running up and down the stairs during the cutscene
+- Setting the difficulty to master (just [remember to switch back](https://youtu.be/LOMo4FBbm7g?si=ndrB2F2Eb8XW85QZ&t=85))
+- Jumping before and after the steer
+- Jumping before and after the steer in real life
+- Only playing the game during a full moon
+
+So far no method has proven 100% effective.
+
 **Ghost ship** \-
 A very rare and strange bug where Barker's ship flies through the control room after Barker drops BT off.
 
 **Viper Zerg** \-
 Refers to the Viper fight strat in which you kill Viper first and use core on the remaining two Titans.
 
-### **THE FOLD WEAPON (FW):**
+**Snake Splitter** \-
+A Viper fight strat in which you abuse a bug with Ions splitter rifle in order to deal absurd amounts of damage.
+
+### **THE FOLD WEAPON (FW)**
 
 **Flotsa Strat** \-
 A strat in which after regaining control of Cooper you walk directly back into the fire and almost die, then walk out. Saves having to wait for BT to talk to you.
@@ -467,8 +546,14 @@ Refers to a wall kick heavy segment in the middle of the Datacore segment.
 **Door skip** \-
 Skips having to wait for enemies to open the door before the final run to Slone fight by disembarking from BT and clipping through the top of the door.
 
+**Rocky Road**\-
+A titanless strat where you move along the rocks at the outskirts of the playable area. Infamous for difficult geometry.
+
 **Triple core Slone** \-
 Refers to a very difficult Slone fight strat that uses 3 cores to complete the fight quickly and setup for Andyshot and Fold Weapon Precharge.
+
+**Fzzy Slone** \-
+Refers to a Slone fight strat that manipulates Slone’s animations in order to cause the Reapers in Phase 2 to drop a few seconds sooner.
 
 **AndyShot** \-
 A cutscene skip performed by using Sword Core immediately before pulling the Ark Injector. Allows you to have your gun out when Blisk walks over your Titan. Shooting Blisk kills him and instantly skips his dialogue.
@@ -476,13 +561,16 @@ A cutscene skip performed by using Sword Core immediately before pulling the Ark
 **Fold Weapon Precharge (Precharge)** \-
 Refers to completing Slone fight fast enough before the “97%” dialogue in the Fold Weapon room, which causes the Fold Weapon to remain charged after BT climbs in and skips the charging sequence.
 
-**Fzzy Slone** \-
-Refers to a Slone fight strat that manipulates Slone’s animations in order to cause the Reapers in Phase 2 to drop a few seconds sooner.
-
 **Zweekscape** \-
 Refers to a route for the “escape” sequence routed by Zweek that takes advantage of the various moving rocks and platforms.
 
-## **MISCELLANEOUS OTHER TERMS:**
+**Hyper Zweekscape** \-
+A variation of Zweekscape which uses a slant boost to gain high speeds.
+
+## **MISCELLANEOUS OTHER TERMS**
+
+**Reverse Trigger Order** \-
+A descriptive name for strats in which you hit triggers in an order not intended by the developers. This can allow for faster routes or messing with the games logic in beneficial ways.
 
 **Quickswap** \-
 Performed by crouching in the middle of a weapon swap animation to swap between weapons faster.

--- a/docs/knowledge-base/glossary/_category_.json
+++ b/docs/knowledge-base/glossary/_category_.json
@@ -1,0 +1,9 @@
+{
+  "label": "Glossary",
+  "position": 2,
+  "collapsed": true,
+  "link": {
+    "type": "generated-index",
+    "description": "A glossary containing terms and phrases used by the community"
+  }
+}

--- a/docs/tutorials/WIP/todo.md
+++ b/docs/tutorials/WIP/todo.md
@@ -1,4 +1,3 @@
-
 # TODO:
 
 Skellys little list of ideas, feel free to add more
@@ -22,7 +21,7 @@ Mats' list:
 
 * [ ] Transfer this list to issues on github(?)
 * [ ] put ultimate movement guide into the wiki (in chunks?) / general movement pages
-* [ ] adopt the [glossary](https://docs.google.com/document/d/1dk5ScogQeL3QTuu-SaG-4zdsouwy1Z2fUYeS0A4niOI/edit) into the wiki
+* [X] adopt the [glossary](https://docs.google.com/document/d/1dk5ScogQeL3QTuu-SaG-4zdsouwy1Z2fUYeS0A4niOI/edit) into the wiki
 * [ ] All helmets tutorials
 * [ ] Level introduction/overview videos
 * [ ] wiki introduction video


### PR DESCRIPTION
Got stuck on a train and decided to port the glossary lol. I'm not entirely certain if there was an 'intended' way you guys wanted the glossary to be ported considering the separate sections for movement and titans under the knowledge base tab, but I felt that it was worth having the glossary anyways. 

Some notable omissions from the new definitions are:
- Xnopyt
- Hellroom Hyper Zipless
- Slant kicks
- Probably something else that I'm forgetting

Mainly due to me not knowing enough about them to provide a solid enough description. 

The definition for the Ship Steer could also do with a second pair of eyes since I decided to have some fun with it. You might want to check whether or not it's the vibe y'all want to go for. 