### PR TITLE
[ENC2] add references to blaidans tutorials

### DIFF
--- a/docs/tutorials/any-percent/08-effect-and-cause-2.mdx
+++ b/docs/tutorials/any-percent/08-effect-and-cause-2.mdx
@@ -22,16 +22,27 @@ Sprint and slide as soon as you gain control to get to Anderson's device. Don't 
 
 ## MVRN Hallways
 
+:::diffe
+### Basic Route
 <YouTube youTubeId="yKOULdFHeQQ" />
+:::
 
+:::diffh
+### Frag Boost
+
+<YouTube youTubeId="muqPb3C2NKk" skipTo={{ h:0, m:10, s:58 }} />
+:::
 ## Fan Room
 
 <YouTube youTubeId="bQU3QigknU0" />
 
 ## Turret Hallways
 
+:::diffe
+### Basic Route
 <YouTube youTubeId="T9w2Br_fZzs" />
 
+:::
 
 
 :::diffm
@@ -62,9 +73,14 @@ As far as frag boosts go, the turret hallways frag is a pretty generous one. The
 
 ### Prespeed
 
+Prespeed is always going to be worth it in dialogue sections like this. Even though this is a medium difficulty strat, I highly recommend going for it even at a beginner level - [icecreamman]
+
 <YouTube youTubeId="qK2-8HFuqj0" />
 
-Prespeed is always going to be worth it in dialogue sections like this. Even though this is a medium difficulty strat, I highly recommend going for it even at a beginner level - [icecreamman]
+# 
+### Faster Prespeed
+
+<YouTube youTubeId="muqPb3C2NKk" skipTo={{ h:0, m:7, s:0}} />
 
 :::
 
@@ -75,12 +91,14 @@ Prespeed is always going to be worth it in dialogue sections like this. Even tho
 
 ### No Prespeed
 
+<YouTube youTubeId="muqPb3C2NKk" skipTo={{ h:0, m:2, s:30 }} />
 :::
 
 :::diffm
 
 ### Simple Prespeed
 
+<YouTube youTubeId="muqPb3C2NKk" skipTo={{ h:0, m:7, s:43 }} />
 :::
 
 :::diffh
@@ -107,6 +125,9 @@ This is not the hardest thing in the universe, but it took me a lot of time to g
 :::
 
 :::diffm
+### Frag
+
+<YouTube youTubeId="muqPb3C2NKk" skipTo={{ h:0, m:8, s:41 }} />
 
 ### Printer hop
 
@@ -116,12 +137,14 @@ This is not the hardest thing in the universe, but it took me a lot of time to g
 
 ### Hellroom Zipless
 
+<YouTube youTubeId="muqPb3C2NKk" skipTo={{ h:0, m:12, s:44 }} />
 :::
 
 :::diffh
 
 ### Hellroom Hyperzipless (HRHZ)
 
+<YouTube youTubeId="muqPb3C2NKk" skipTo={{ h:0, m:13, s:45 }} />
 :::
 
 
@@ -131,7 +154,10 @@ This is not the hardest thing in the universe, but it took me a lot of time to g
 :::diffm
 
 ### Snuggleslide
+While being a medium difficulty strat, missing Snuggleslide doesn't lose any time and so it is recommended to try the strat at any skill level. 
 
+<YouTube youTubeId="H0PpH2VV9MY" skipTo={{ h:0, m:15, s:37 }} />
+ 
 :::
 
 ## Anderson Log 3


### PR DESCRIPTION
Life's gotten in the way a lot recently but I managed to find some time to squeeze out another update. 

There is still a lot of work to be done with this level, but I feel like this is a good step on the way. What I can tell already is missing is a good solution on how to structure hellroom for the lower difficulty levels. I couldn't find a good tutorial that didn't also sort of bleed in to printer hop or some other strat, and I haven't touched cryo at all yet. The intro could also use some work but it's so short that I find it a bit clunky to link to an entire tutorial just for a quick 3 second explanation. 